### PR TITLE
Parse COG geometries from productInfo.json

### DIFF
--- a/src/stactools/sentinel1/grd/metadata_links.py
+++ b/src/stactools/sentinel1/grd/metadata_links.py
@@ -78,6 +78,7 @@ class MetadataLinks:
         self.product_metadata_href = os.path.join(granule_href,
                                                   "manifest.safe")
 
+        self.product_info = None
         if archive_format == Format.COG:
             self.product_info_href = os.path.join(granule_href,
                                                   "productInfo.json")

--- a/src/stactools/sentinel1/grd/product_metadata.py
+++ b/src/stactools/sentinel1/grd/product_metadata.py
@@ -26,14 +26,9 @@ def get_shape(meta_links: MetadataLinks,
 
 
 class ProductMetadata:
-    def __init__(
-        self,
-        href,
-        file_hrefs: Dict[str, List[str]],
-        file_mapper: Callable[[str], str],
-        manifest: XmlElement,
-        product_info: Optional[Dict]
-    ) -> None:
+    def __init__(self, href, file_hrefs: Dict[str, List[str]],
+                 file_mapper: Callable[[str], str], manifest: XmlElement,
+                 product_info: Optional[Dict]) -> None:
         self.href = href
         self._root = manifest
         self.file_hrefs = file_hrefs
@@ -51,8 +46,8 @@ class ProductMetadata:
                     )
                 # Convert to values
                 footprint_value = [
-                    float(x)
-                    for x in footprint_text[0].text.replace(" ", ",").split(",")
+                    float(x) for x in footprint_text[0].text.replace(
+                        " ", ",").split(",")
                 ]
 
                 footprint_points = [
@@ -70,7 +65,9 @@ class ProductMetadata:
 
                 def parse_polygon(geom: List):
                     def fail():
-                        raise RuntimeError(f"Can't parse Polygon from: {json.dumps(geom)} for {href}")
+                        raise RuntimeError(
+                            f"Can't parse Polygon from: {json.dumps(geom)} for {href}"
+                        )
 
                     if len(geom) > 1:
                         if not isinstance(geom[0], List):
@@ -78,7 +75,8 @@ class ProductMetadata:
                         if len(geom[0]) == 2:
                             if not isinstance(geom[0][0], float):
                                 fail()
-                            return Polygon([(point[0], point[1]) for point in geom])
+                            return Polygon([(point[0], point[1])
+                                            for point in geom])
                     elif len(geom) == 1:
                         return parse_polygon(geom[0])
                     else:

--- a/src/stactools/sentinel1/grd/product_metadata.py
+++ b/src/stactools/sentinel1/grd/product_metadata.py
@@ -2,9 +2,11 @@ from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
 
 from pystac.utils import str_to_datetime
-from shapely.geometry import Polygon, mapping, MultiPolygon, LineString  # type: ignore
+from shapely.geometry import MultiPolygon  # type: ignore
+from shapely.geometry import Polygon, mapping
 from stactools.core.io import ReadHrefModifier
 from stactools.core.io.xml import XmlElement
+
 from stactools.sentinel1.grd.metadata_links import MetadataLinks
 
 
@@ -63,9 +65,11 @@ class ProductMetadata:
                 if geom_type.lower() == "polygon":
                     footprint_geom = Polygon(*coordinates)
                 elif geom_type.lower() == "multipolygon":
-                    footprint_geom = MultiPolygon(coordinates, context_type="geojson")
+                    footprint_geom = MultiPolygon(coordinates,
+                                                  context_type="geojson")
                 else:
-                    raise RuntimeError("Can't read geometry of type " + geom_type)
+                    raise RuntimeError("Can't read geometry of type " +
+                                       geom_type)
 
                 geometry = mapping(footprint_geom)
                 bbox = footprint_geom.bounds

--- a/src/stactools/sentinel1/grd/product_metadata.py
+++ b/src/stactools/sentinel1/grd/product_metadata.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
 
@@ -31,6 +32,7 @@ class ProductMetadata:
         file_hrefs: Dict[str, List[str]],
         file_mapper: Callable[[str], str],
         manifest: XmlElement,
+        product_info: Optional[Dict]
     ) -> None:
         self.href = href
         self._root = manifest
@@ -40,27 +42,53 @@ class ProductMetadata:
         self.resolution = self.product_id.split("_")[2][-1]
 
         def _get_geometries():
-            # Find the footprint descriptor
-            footprint_text = self._root.findall(".//gml:coordinates")
-            if footprint_text is None:
-                ProductMetadataError(
-                    f"Cannot parse footprint from product metadata at {self.href}"
-                )
-            # Convert to values
-            footprint_value = [
-                float(x)
-                for x in footprint_text[0].text.replace(" ", ",").split(",")
-            ]
+            if product_info is None:
+                # Find the footprint descriptor
+                footprint_text = self._root.findall(".//gml:coordinates")
+                if footprint_text is None:
+                    ProductMetadataError(
+                        f"Cannot parse footprint from product metadata at {self.href}"
+                    )
+                # Convert to values
+                footprint_value = [
+                    float(x)
+                    for x in footprint_text[0].text.replace(" ", ",").split(",")
+                ]
 
-            footprint_points = [
-                p[::-1] for p in list(zip(*[iter(footprint_value)] * 2))
-            ]
+                footprint_points = [
+                    p[::-1] for p in list(zip(*[iter(footprint_value)] * 2))
+                ]
 
-            footprint_polygon = Polygon(footprint_points)
-            geometry = mapping(footprint_polygon)
-            bbox = footprint_polygon.bounds
+                footprint_polygon = Polygon(footprint_points)
+                geometry = mapping(footprint_polygon)
+                bbox = footprint_polygon.bounds
 
-            return (bbox, geometry)
+                return bbox, geometry
+
+            else:
+                geometry = product_info["footprint"]["coordinates"]
+
+                def parse_polygon(geom: List):
+                    def fail():
+                        raise RuntimeError(f"Can't parse Polygon from: {json.dumps(geom)} for {href}")
+
+                    if len(geom) > 1:
+                        if not isinstance(geom[0], List):
+                            fail()
+                        if len(geom[0]) == 2:
+                            if not isinstance(geom[0][0], float):
+                                fail()
+                            return Polygon([(point[0], point[1]) for point in geom])
+                    elif len(geom) == 1:
+                        return parse_polygon(geom[0])
+                    else:
+                        fail()
+
+                footprint_polygon = parse_polygon(geometry)
+                geometry = mapping(footprint_polygon)
+                bbox = footprint_polygon.bounds
+
+                return bbox, geometry
 
         self.bbox, self.geometry = _get_geometries()
 

--- a/src/stactools/sentinel1/grd/stac.py
+++ b/src/stactools/sentinel1/grd/stac.py
@@ -47,6 +47,7 @@ def create_item(
         metalinks.grouped_hrefs,
         metalinks.map_filename,
         metalinks.manifest,
+        metalinks.product_info
     )
 
     item = pystac.Item(

--- a/src/stactools/sentinel1/grd/stac.py
+++ b/src/stactools/sentinel1/grd/stac.py
@@ -82,7 +82,8 @@ def create_item(
         extra_properties["s1:shape"] = shape
 
     item.properties.update({
-        **product_metadata.metadata_dict, **extra_properties
+        **product_metadata.metadata_dict,
+        **extra_properties
     })
 
     # Add assets to item

--- a/src/stactools/sentinel1/grd/stac.py
+++ b/src/stactools/sentinel1/grd/stac.py
@@ -75,9 +75,14 @@ def create_item(
     item.common_metadata.constellation = SENTINEL_CONSTELLATION
 
     # s1 properties
-    shape = get_shape(metalinks, read_href_modifier)
+    extra_properties = {}
+
+    if not os.getenv("SKIP_SHAPE"):
+        shape = get_shape(metalinks, read_href_modifier)
+        extra_properties["s1:shape"] = shape
+
     item.properties.update({
-        **product_metadata.metadata_dict, "s1:shape": shape
+        **product_metadata.metadata_dict, **extra_properties
     })
 
     # Add assets to item

--- a/src/stactools/sentinel1/grd/stac.py
+++ b/src/stactools/sentinel1/grd/stac.py
@@ -42,13 +42,11 @@ def create_item(
 
     metalinks = MetadataLinks(granule_href, read_href_modifier, archive_format)
 
-    product_metadata = ProductMetadata(
-        metalinks.product_metadata_href,
-        metalinks.grouped_hrefs,
-        metalinks.map_filename,
-        metalinks.manifest,
-        metalinks.product_info
-    )
+    product_metadata = ProductMetadata(metalinks.product_metadata_href,
+                                       metalinks.grouped_hrefs,
+                                       metalinks.map_filename,
+                                       metalinks.manifest,
+                                       metalinks.product_info)
 
     item = pystac.Item(
         id=product_metadata.scene_id,

--- a/tests/grd/test_metadata.py
+++ b/tests/grd/test_metadata.py
@@ -24,7 +24,8 @@ class Sentinel1MetadataTest(unittest.TestCase):
         product_metadata = ProductMetadata(metalinks.product_metadata_href,
                                            metalinks.grouped_hrefs,
                                            metalinks.map_filename,
-                                           metalinks.manifest)
+                                           metalinks.manifest,
+                                           metalinks.product_info)
 
         item = pystac.Item(
             id=product_metadata.scene_id,


### PR DESCRIPTION
**Description:**
Add support for parsing geometries in COG format Sentinel-1 GRD products from `productInfo.json` file. This file is created on conversion to COG and can contain more precise geometries.

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [ ] ~~Changes are added to the [CHANGELOG](../CHANGELOG.md).~~ (minor change)
