### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### Fixed
-
-- Temporal extent for the RTC Collection, and some typing ([#17](https://github.com/stactools-packages/sentinel1/pull/17))
-
-## [v0.2.1] - 2021-11-08
+## [0.3.0] - 2022-12-01
 
 ### Added
 
@@ -22,13 +18,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Rename GRD schema keys to better reflect their contents
 - Ensure RTC Items list RasterExtension (#16)
 
-## [v0.2.0] - 2021-09-09
+### Fixed
+
+- Temporal extent for the RTC Collection, and some typing ([#17](https://github.com/stactools-packages/sentinel1/pull/17))
+
+## [0.2.0] - 2021-09-09
 
 - Added `stac sentinel1 grd` subcommand
 - `stac sentinel1 create-item` now required subcommand `grd` or `rtc`
 - Support for Microsoft Azure storage: similar format to SAFE, without `.SAFE` ending to the folders and slightly different file names.
 
-## [v0.1.0] - 2021-09-04
+## [0.1.0] - 2021-09-04
 
 - Initial release!
 - Support for Sentinel1 AWS RTC public dataset
+
+[Unreleased]: https://github.com/stactools-packages/sentinel1/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/stactools-packages/sentinel1/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/stactools-packages/sentinel1/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/stactools-packages/sentinel1/releases/tag/v0.1.0

--- a/src/stactools/sentinel1/__init__.py
+++ b/src/stactools/sentinel1/__init__.py
@@ -12,4 +12,4 @@ def register_plugin(registry: Registry):
     registry.register_subcommand(create_sentinel1_command)
 
 
-__version__ = '0.2.1'
+__version__ = '0.3.0'


### PR DESCRIPTION
**Related Issue(s):**
- There's changes requested on #14 and no other open PRs.

**Description:**
Includes a clean up the changelog -- v0.2.1 was never released.

The return type of a couple of public functions was changed since v0.2.0, so this requires a MAJOR release.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
