### PR TITLE
Allow passing generic kwargs for IO operations.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ package_dir =
     = src
 packages = find_namespace:
 install_requires =
-    stactools @ git+https://github.com/sharkinsspatial/stactools.git@kwargs_subclass
+    stactools == 0.4.3
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ package_dir =
     = src
 packages = find_namespace:
 install_requires =
-    stactools == 0.2.1
+    stactools @ git+https://github.com/sharkinsspatial/stactools.git@kwargs_subclass
 
 [options.packages.find]
 where = src

--- a/src/stactools/sentinel1/grd/metadata_links.py
+++ b/src/stactools/sentinel1/grd/metadata_links.py
@@ -63,12 +63,14 @@ class MetadataLinks:
     def __init__(self,
                  granule_href: str,
                  read_href_modifier: Optional[ReadHrefModifier] = None,
-                 archive_format: Format = Format.SAFE) -> None:
+                 archive_format: Format = Format.SAFE,
+                 **kwargs) -> None:
         self.granule_href = granule_href
         self.href = os.path.join(granule_href, "manifest.safe")
         self.archive_format = archive_format
 
-        self.manifest = XmlElement.from_file(self.href, read_href_modifier)
+        self.manifest = XmlElement.from_file(self.href, read_href_modifier,
+                                             **kwargs)
         data_object_section = self.manifest.find("dataObjectSection")
         if data_object_section is None:
             raise ManifestError(
@@ -83,7 +85,7 @@ class MetadataLinks:
                                                   "productInfo.json")
             self.product_info = json.loads(
                 stactools.core.io.read_text(self.product_info_href,
-                                            read_href_modifier))
+                                            read_href_modifier, **kwargs))
             self.filename_map = self.product_info["filenameMap"]
 
         file_location_list = self._data_object_section.findall(

--- a/src/stactools/sentinel1/grd/product_metadata.py
+++ b/src/stactools/sentinel1/grd/product_metadata.py
@@ -13,11 +13,9 @@ class ProductMetadataError(Exception):
     pass
 
 
-def get_shape(
-    meta_links: MetadataLinks,
-    read_href_modifier: Optional[ReadHrefModifier],
-    **kwargs: Any
-) -> List[int]:
+def get_shape(meta_links: MetadataLinks,
+              read_href_modifier: Optional[ReadHrefModifier],
+              **kwargs: Any) -> List[int]:
     links = meta_links.create_product_asset()
     root = XmlElement.from_file(links[0][1].href, read_href_modifier, **kwargs)
 

--- a/src/stactools/sentinel1/grd/product_metadata.py
+++ b/src/stactools/sentinel1/grd/product_metadata.py
@@ -13,10 +13,13 @@ class ProductMetadataError(Exception):
     pass
 
 
-def get_shape(meta_links: MetadataLinks,
-              read_href_modifier: Optional[ReadHrefModifier]) -> List[int]:
+def get_shape(
+    meta_links: MetadataLinks,
+    read_href_modifier: Optional[ReadHrefModifier],
+    **kwargs: Any
+) -> List[int]:
     links = meta_links.create_product_asset()
-    root = XmlElement.from_file(links[0][1].href, read_href_modifier)
+    root = XmlElement.from_file(links[0][1].href, read_href_modifier, **kwargs)
 
     x_size = int(root.findall(".//numberOfSamples")[0].text)
     y_size = int(root.findall(".//numberOfLines")[0].text)

--- a/src/stactools/sentinel1/grd/stac.py
+++ b/src/stactools/sentinel1/grd/stac.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Optional
+from typing import Optional, Any
 
 import pystac
 from pystac.extensions.eo import EOExtension
@@ -23,6 +23,7 @@ def create_item(
     granule_href: str,
     read_href_modifier: Optional[ReadHrefModifier] = None,
     archive_format: Format = Format.SAFE,
+    **kwargs: Any,
 ) -> pystac.Item:
     """Create a STC Item from a Sentinel-1 GRD scene.
 
@@ -40,7 +41,12 @@ def create_item(
         pystac.Item: An item representing the Sentinel-1 GRD scene.
     """
 
-    metalinks = MetadataLinks(granule_href, read_href_modifier, archive_format)
+    metalinks = MetadataLinks(
+        granule_href,
+        read_href_modifier,
+        archive_format,
+        **kwargs,
+    )
 
     product_metadata = ProductMetadata(
         metalinks.product_metadata_href,
@@ -76,7 +82,7 @@ def create_item(
     item.common_metadata.constellation = SENTINEL_CONSTELLATION
 
     # s1 properties
-    shape = get_shape(metalinks, read_href_modifier)
+    shape = get_shape(metalinks, read_href_modifier, **kwargs)
     item.properties.update({
         **product_metadata.metadata_dict, "s1:shape": shape
     })

--- a/src/stactools/sentinel1/grd/stac.py
+++ b/src/stactools/sentinel1/grd/stac.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Optional, Any
+from typing import Any, Optional
 
 import pystac
 from pystac.extensions.eo import EOExtension


### PR DESCRIPTION
Before you submit a pull request, please fill in the following:

**Related Issue(s):**
This PR applies the functionality included in the core stactools module from https://github.com/stac-utils/stactools/pull/372.

**Description:**
Fsspec backends may require generic `kwargs` provided by the client (`requester_pays` as an example).

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).
