### PR TITLE
Fix for cog format to work with added polarization to item-asset titles for schemas and data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ number as needed.
 
 ## [Unreleased] - TBD
 
+### Fixed
+
+- Fixed updated item-asset titles to work with COG format granules. ([#37](https://github.com/stactools-packages/sentinel1/pull/37))
+
 ### Added
 
 - Added polarization to item-asset titles for schemas and data ([#35](https://github.com/stactools-packages/sentinel1/pull/35))

--- a/src/stactools/sentinel1/grd/metadata_links.py
+++ b/src/stactools/sentinel1/grd/metadata_links.py
@@ -32,6 +32,14 @@ dataset_naming_pattern = re.compile(
 )
 
 
+def extract_polarisation(href: str) -> str:
+    match = re.search(r"(hh|hv|vv|vh)", href)
+    if match:
+        return match.group(0).upper()
+    else:
+        raise RuntimeError(f"Failed to match polarisation: {href}")
+
+
 def extract_properties(href: str, properties: List[str]) -> List[str]:
     matches = dataset_naming_pattern.match(href)
     if matches is not None:
@@ -199,19 +207,19 @@ class MetadataLinks:
             "location, etc."
         )
         for key, href in self.annotation_hrefs:
-            # Extract polarisation from href using extract_properties
-            polarisation = extract_properties(href, ["polarisation"])[0].upper()
-            # Create a unique title for each asset using the extracted polarisation
-            title = f"{polarisation} Product Schema"
-
-            asset = pystac.Asset(
-                href=href,
-                media_type=pystac.MediaType.XML,
-                title=title,
-                roles=["metadata"],
-                description=desc,
-            )
-            assets.append((key, asset))
+            # Extract polarisation from href
+            polarisation = extract_polarisation(href)
+            if polarisation:
+                # Add polarisation to title
+                title = f"{polarisation} Product Schema"
+                asset = pystac.Asset(
+                    href=href,
+                    media_type=pystac.MediaType.XML,
+                    title=title,
+                    roles=["metadata"],
+                    description=desc,
+                )
+                assets.append((key, asset))
         return assets
 
     def create_calibration_asset(self) -> List[Tuple[str, pystac.asset.Asset]]:
@@ -222,34 +230,35 @@ class MetadataLinks:
             "absolute product calibration."
         )
         for key, href in self.calibration_hrefs:
-            # Extract polarisation from href using extract_properties
-            polarisation = extract_properties(href, ["polarisation"])[0].upper()
-            # Create a unique title for each asset using the extracted polarisation
-            title = f"{polarisation} Calibration Schema"
-
-            asset = pystac.Asset(
-                href=href,
-                media_type=pystac.MediaType.XML,
-                title=title,
-                roles=["metadata"],
-                description=desc,
-            )
-            assets.append((key, asset))
+            # Extract polarisation from href
+            polarisation = extract_polarisation(href)
+            if polarisation:
+                # Add polarisation to title
+                title = f"{polarisation} Calibration Schema"
+                asset = pystac.Asset(
+                    href=href,
+                    media_type=pystac.MediaType.XML,
+                    title=title,
+                    roles=["metadata"],
+                    description=desc,
+                )
+                assets.append((key, asset))
         return assets
 
     def create_noise_asset(self) -> List[Tuple[str, pystac.asset.Asset]]:
         assets = []
         for key, href in self.noise_hrefs:
-            # Extract polarisation from href using extract_properties
-            polarisation = extract_properties(href, ["polarisation"])[0].upper()
-            # Create a unique title for each asset using the extracted polarisation
-            title = f"{polarisation} Noise Schema"
-            asset = pystac.Asset(
-                href=href,
-                media_type=pystac.MediaType.XML,
-                title=title,
-                roles=["metadata"],
-                description="Estimated thermal noise look-up tables",
-            )
-            assets.append((key, asset))
+            # Extract polarisation from href
+            polarisation = extract_polarisation(href)
+            if polarisation:
+                # Add polarisation to title
+                title = f"{polarisation} Noise Schema"
+                asset = pystac.Asset(
+                    href=href,
+                    media_type=pystac.MediaType.XML,
+                    title=title,
+                    roles=["metadata"],
+                    description="Estimated thermal noise look-up tables",
+                )
+                assets.append((key, asset))
         return assets


### PR DESCRIPTION

**Related Issue(s):**
na

**Description:**
Fix for cog format to work with added polarization to item-asset titles for schemas and data

**PR checklist:**

- [X] Code is formatted (run `scripts/format`).
- [X] Code lints properly (run `scripts/lint`).
- [X] Tests pass (run `scripts/test`).
- [X] Documentation has been updated to reflect changes, if applicable.
- [X] Examples have been updated to reflect changes, if applicable
- [X] Changes are added to the [CHANGELOG](../CHANGELOG.md).
