### PR TITLE
unpin stactools from ==0.4.5 to >=0.4.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ package_dir =
 packages = find_namespace:
 python_requires = >= 3.8
 install_requires =
-    stactools == 0.4.5
+    stactools >= 0.4.5
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
**Related Issue(s):**

n/a

**Description:**

unpin stactools from ==0.4.5 to >=0.4.5, primarily to allow the use of RasterFootprint in stactools 0.4.7 in any package that uses this package

**PR checklist:**

- [X] Code is formatted (run `scripts/format`).
- [X] Code lints properly (run `scripts/lint`).
- [X] Tests pass (run `scripts/test`).
- [X] Documentation has been updated to reflect changes, if applicable.
- [X] Examples have been updated to reflect changes, if applicable
- [X] Changes are added to the [CHANGELOG](../CHANGELOG.md).
