### PR TITLE
fix polarization detection wrt filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project attempts to match the major and minor versions of
 [stactools](https://github.com/stac-utils/stactools) and increments the patch
 number as needed.
 
+## [Unreleased] - TBD
+
+### Fixed
+
+- Fixed polarization detection used when determining the asset title ([]())
+
 ## [v0.6.0] - 2023-05-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ number as needed.
 
 ### Fixed
 
-- Fixed polarization detection used when determining the asset title ([]())
+- Fixed polarization detection used when determining the asset title ([#49](https://github.com/stactools-packages/sentinel1/pull/49))
 
 ## [v0.6.0] - 2023-05-09
 

--- a/src/stactools/sentinel1/grd/metadata_links.py
+++ b/src/stactools/sentinel1/grd/metadata_links.py
@@ -33,11 +33,13 @@ dataset_naming_pattern = re.compile(
 
 
 def extract_polarisation(href: str) -> str:
-    match = re.search(r"(hh|hv|vv|vh)", href)
-    if match:
-        return match.group(0).upper()
-    else:
-        raise RuntimeError(f"Failed to match polarisation: {href}")
+    if match := (
+        re.search(r"ew-(hh|hv|vv|vh)\.(?:tiff|xml)$", href)
+        or re.search(r"s1(?:a|b)-iw-grd-(hh|hv|vv|vh)-[-\w]+\.(?:tiff|xml)$", href)
+    ):
+        return match.group(1).upper()
+
+    raise RuntimeError(f"Failed to match polarisation: {href}")
 
 
 def extract_properties(href: str, properties: List[str]) -> List[str]:

--- a/tests/grd/test_metadata_links.py
+++ b/tests/grd/test_metadata_links.py
@@ -1,0 +1,23 @@
+from stactools.sentinel1.grd.metadata_links import extract_polarisation
+
+
+def test_extract_polarization() -> None:
+    paths_to_polarization = {
+        "S1A_IW_GRDH_1SDV_20210809T173953_20210809T174018_039156_049F13_6FF8.SAFE/measurement/s1a-iw-grd-vh-20210809t173953-20210809t174018-039156-049f13-002.tiff": "VH",  # noqa: E501
+        "S1A_IW_GRDH_1SDV_20210809T173953_20210809T174018_039156_049F13_6FF8.SAFE/measurement/s1a-iw-grd-vv-20210809t173953-20210809t174018-039156-049f13-001.tiff": "VV",  # noqa: E501
+        "S1A_IW_GRDH_1SDV_20210809T173953_20210809T174018_039156_049F13_6FF8.SAFE/measurement/s1a-iw-grd-hh-20210809t173953-20210809t174018-039156-049f13-001.tiff": "HH",  # noqa: E501
+        "S1A_IW_GRDH_1SDV_20210809T173953_20210809T174018_039156_049F13_6FF8.SAFE/measurement/s1a-iw-grd-hv-20210809t173953-20210809t174018-039156-049f13-001.tiff": "HV",  # noqa: E501
+        "S1A_EW_GRDM_1SDH_20221130T014342_20221130T014446_046117_058549_BB15/measurement/ew-hh.tiff": "HH",  # noqa: E501
+        "S1A_EW_GRDM_1SDH_20221130T014342_20221130T014446_046117_058549_BB15/measurement/ew-hv.tiff": "HV",  # noqa: E501
+        "S1A_EW_GRDM_1SDH_20221130T014342_20221130T014446_046117_058549_BB15/measurement/ew-vv.tiff": "VV",  # noqa: E501
+        "S1A_EW_GRDM_1SDH_20221130T014342_20221130T014446_046117_058549_BB15/measurement/ew-vh.tiff": "VH",  # noqa: E501
+    }
+
+    # initially, the extract_polarization looked for the two-letter polarization anywhere
+    # in the path, which led to many false-detections in temp directories
+    for test_polarization in ["vv", "vh", "hv", "hh"]:
+        for path, expected_polarization in paths_to_polarization.items():
+            assert (
+                extract_polarisation(f"some_path/xx{test_polarization}yy/{path}")
+                == expected_polarization
+            )


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/stactools-packages/sentinel1/issues/48

**Description:**

Previously, the filename -> polarization check was too loose, so any use of vh, vv, hv, or hh in the entire file path would match, and frequently give incorrect results. This was particularly apparent when downloading files into temp directories as would be done in an ingest process. This PR tightens the regex so it it will only match the filename.

**PR checklist:**

- [X] Code is formatted (run `scripts/format`).
- [X] Code lints properly (run `scripts/lint`).
- [X] Tests pass (run `scripts/test`).
- [X] Documentation has been updated to reflect changes, if applicable.
- [X] Examples have been updated to reflect changes, if applicable
- [X] Changes are added to the [CHANGELOG](../CHANGELOG.md).
