### PR TITLE
GRD: make platform property lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ number as needed.
 
 ### Changed
 
-- GRD: `platform` property is now lowercase to conform with STAC spec recommendations. This also makes it consistent with the values defined in the Collection Summaries. ([]())
+- GRD: `platform` property is now lowercase to conform with STAC spec recommendations. This also makes it consistent with the values defined in the Collection Summaries. ([#50](https://github.com/stactools-packages/sentinel1/pull/50))
 
 ## [v0.6.0] - 2023-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project attempts to match the major and minor versions of
 [stactools](https://github.com/stac-utils/stactools) and increments the patch
 number as needed.
 
+## [Unreleased] - TBD
+
+### Changed
+
+- GRD: `platform` property is now lowercase to conform with STAC spec recommendations. This also makes it consistent with the values defined in the Collection Summaries. ([]())
+
 ## [v0.6.0] - 2023-05-09
 
 ### Changed

--- a/src/stactools/sentinel1/grd/stac.py
+++ b/src/stactools/sentinel1/grd/stac.py
@@ -154,7 +154,11 @@ def create_item(
 
     # --Common metadata--
     item.common_metadata.providers = [c.SENTINEL_PROVIDER]
-    item.common_metadata.platform = product_metadata.platform
+    item.common_metadata.platform = (
+        product_metadata.platform.lower()
+        if product_metadata.platform
+        else product_metadata.platform
+    )
     item.common_metadata.constellation = c.SENTINEL_CONSTELLATION
 
     # Add s1 properties

--- a/tests/grd/test_stac.py
+++ b/tests/grd/test_stac.py
@@ -2,7 +2,9 @@ import pystac
 from pystac.extensions.eo import EOExtension
 from pystac.utils import is_absolute_href
 
-from stactools.sentinel1.grd import Format, stac
+from stactools.sentinel1.grd import Format
+from stactools.sentinel1.grd import constants as c
+from stactools.sentinel1.grd import stac
 from stactools.sentinel1.grd.constants import SENTINEL_POLARIZATIONS
 from tests import test_data
 
@@ -50,6 +52,9 @@ def test_create_item() -> None:
 
     assert item.properties.get("start_datetime") == "2021-08-09T17:39:53.153776Z"
     assert item.properties.get("end_datetime") == "2021-08-09T17:40:18.152800Z"
+
+    assert item.properties.get("constellation") == c.SENTINEL_CONSTELLATION
+    assert item.properties.get("platform") == "sentinel-1a"
 
     assert item.properties.get("proj:epsg") == 4326
     assert item.properties.get("proj:bbox") == [


### PR DESCRIPTION
**Related Issue(s):**

- #47 

**Description:**

The platform property is now lowercase to conform with the STAC spec recommendation that these fields be lowercase.

**PR checklist:**

- [X] Code is formatted (run `scripts/format`).
- [X] Code lints properly (run `scripts/lint`).
- [X] Tests pass (run `scripts/test`).
- [X] Documentation has been updated to reflect changes, if applicable.
- [X] Examples have been updated to reflect changes, if applicable
- [X] Changes are added to the [CHANGELOG](../CHANGELOG.md).
