### PR TITLE
grd: relax polarization regex to capture all files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project attempts to match the major and minor versions of
 [stactools](https://github.com/stac-utils/stactools) and increments the patch
 number as needed.
 
+## [Unreleased] - TBD
+
+## Fixed
+
+- Relaxed polarization regex to work with all files in a scene ([#53](https://github.com/stactools-packages/sentinel1/pull/53))
+
 ## [0.7.0] - 2023-05-10
 
 ### Changed

--- a/src/stactools/sentinel1/grd/metadata_links.py
+++ b/src/stactools/sentinel1/grd/metadata_links.py
@@ -34,7 +34,7 @@ dataset_naming_pattern = re.compile(
 
 def extract_polarisation(href: str) -> str:
     if match := (
-        re.search(r"ew-(hh|hv|vv|vh)\.(?:tiff|xml)$", href)
+        re.search(r"-(hh|hv|vv|vh)\.(?:tiff|xml)$", href)
         or re.search(r"s1(?:a|b)-iw-grd-(hh|hv|vv|vh)-[-\w]+\.(?:tiff|xml)$", href)
     ):
         return match.group(1).upper()

--- a/tests/grd/test_metadata_links.py
+++ b/tests/grd/test_metadata_links.py
@@ -11,6 +11,7 @@ def test_extract_polarization() -> None:
         "S1A_EW_GRDM_1SDH_20221130T014342_20221130T014446_046117_058549_BB15/measurement/ew-hv.tiff": "HV",  # noqa: E501
         "S1A_EW_GRDM_1SDH_20221130T014342_20221130T014446_046117_058549_BB15/measurement/ew-vv.tiff": "VV",  # noqa: E501
         "S1A_EW_GRDM_1SDH_20221130T014342_20221130T014446_046117_058549_BB15/measurement/ew-vh.tiff": "VH",  # noqa: E501
+        "/var/folders/3q/jb-vv.xmlg6x0zx3194zq6_2jbwygjw0000gn/T/tmpe46tss8d/S1A_S3_GRDH_1SDV_20200101T152850_20200101T152909_030608_0381BB_B254/annotation/s3-vh.xml": "VH",  # noqa: E501
     }
 
     # initially, the extract_polarization looked for the two-letter polarization anywhere


### PR DESCRIPTION
**Related Issue(s):**

n/a

**Description:**

The regex to determine polarization was too tight, so relax it to capture all relevant files.

**PR checklist:**

- [X] Code is formatted (run `scripts/format`).
- [X] Code lints properly (run `scripts/lint`).
- [X] Tests pass (run `scripts/test`).
- [X] Documentation has been updated to reflect changes, if applicable.
- [X] Examples have been updated to reflect changes, if applicable
- [X] Changes are added to the [CHANGELOG](../CHANGELOG.md).
