### PR TITLE
Relax pystac pin (~=1.9.0 -> ~=1.9) for modern pystac compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ This project attempts to match the major and minor versions of
 [stactools](https://github.com/stac-utils/stactools) and increments the patch
 number as needed.
 
+## [Unreleased]
+
+### Changed
+
+- Relaxed the `pystac` dependency from `~= 1.9.0` to `~= 1.9` so the package can
+  be installed alongside pystac 1.10+. The previous
+  specifier stranded downstream projects on modern pystac and blocked them
+  from the Sentinel-1C/1D regex fix (#62); the wider `~= 1.9` (`>=1.9,<2.0`) keeps the major-version guard.
+  ([#NN](https://github.com/stactools-packages/sentinel1/pull/NN))
+  
 ## [0.8.1] - 2025-05-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ number as needed.
   be installed alongside pystac 1.10+. The previous
   specifier stranded downstream projects on modern pystac and blocked them
   from the Sentinel-1C/1D regex fix (#62); the wider `~= 1.9` (`>=1.9,<2.0`) keeps the major-version guard.
-  ([#NN](https://github.com/stactools-packages/sentinel1/pull/NN))
+  ([#64](https://github.com/stactools-packages/sentinel1/pull/64))
   
 ## [0.8.1] - 2025-05-13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "stactools >= 0.4.5",
-    "pystac ~= 1.9.0",
+    "pystac ~= 1.9",
 ]
 requires-python = ">=3.9"
 


### PR DESCRIPTION
## What

Relax the `pystac` dependency in `pyproject.toml` from `~= 1.9.0` to `~= 1.9`.

## Why

`~= 1.9.0` resolves to `>=1.9.0, <1.10.0`, so the package cannot be installed
alongside pystac 1.10 or newer (current release is 1.14). This pin was
introduced in 0.8.1 — the same release that added the Sentinel-1C/1D mission
regex fix (#62).

The net effect: downstream projects on modern pystac can't use 0.8.1, so they're
forced back to 0.8.0, which predates #62 and therefore lacks Sentinel-1C/1D
support. So we end up working around it (difficult to maintain monkeypatching) instead 
of simply upgrading.

`~= 1.9` widens the constraint to `>=1.9, <2.0`, admitting pystac 1.10–1.x while
retaining a guard against a hypothetical breaking 2.0.

## Changes

- `pyproject.toml`: `pystac ~= 1.9.0` -> `pystac ~= 1.9`
- `CHANGELOG.md`: entry under `[Unreleased]`

No source/code changes — dependency metadata only.

## PR checklist

- [X] Code is formatted (run `scripts/format`).
- [X] Code lints properly (run `scripts/lint`).
- [X] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [ ] Examples have been updated to reflect changes, if applicable
- [X] Changes are added to the [CHANGELOG](../CHANGELOG.md).
